### PR TITLE
Fixing build error for macOS and memory leak for all platforms.

### DIFF
--- a/util.c
+++ b/util.c
@@ -1383,7 +1383,7 @@ char *Strcasestr(char *haystack, const char *needle)
 	for (i = 0; i < nlen; i++)
 		lowneedle[i] = tolower(needle[i]);
 	ret = strstr(lowhay, lowneedle);
-	if (!ret)
+	if (ret)
     {
         ofs = ret - lowhay;
         ret = haystack + ofs;

--- a/util.c
+++ b/util.c
@@ -1384,9 +1384,15 @@ char *Strcasestr(char *haystack, const char *needle)
 		lowneedle[i] = tolower(needle[i]);
 	ret = strstr(lowhay, lowneedle);
 	if (!ret)
-		return ret;
-	ofs = ret - lowhay;
-	return haystack + ofs;
+    {
+        ofs = ret - lowhay;
+        ret = haystack + ofs;
+    }
+    
+    free(lowhay);
+    free(lowneedle);
+    
+    return ret;
 }
 
 char *Strsep(char **stringp, const char *delim)

--- a/util.h
+++ b/util.h
@@ -159,6 +159,7 @@ void ckrecalloc(void **ptr, size_t old, size_t new, const char *file, const char
 #define recalloc(ptr, old, new) ckrecalloc((void *)&(ptr), old, new, __FILE__, __func__, __LINE__)
 char *recv_line(struct pool *pool);
 bool parse_method(struct pool *pool, char *s);
+bool subscribe_extranonce(struct pool *pool);
 bool extract_sockaddr(char *url, char **sockaddr_url, char **sockaddr_port);
 bool auth_stratum(struct pool *pool);
 bool initiate_stratum(struct pool *pool);


### PR DESCRIPTION
I'm not sure why no one else has fixed this yet, but cgminer.c fails to compiler on macOS because it uses subscribe_extranonce() from util.c, but its prototype is missing from util.h.  C99 doesn't allow implicit function declarations.  The fix was simple - just added subscribe_extranonce to util.h.  Maybe it's a clang vs. gcc configuration issue.  Strangely it didn't happen on the first build after cloning and configuring the project, but if a change is made (not even to cgminer.c or having anything to do with util.h), then it shows up.

I also fixed a bug in Strcasestr() where two local pointers are allocated, but never deallocated.   They don't escape the function, so failing to deallocate them was a leak.  Basically the function is a case-insensitive version of strstr(), and the two strings were used to make lowercase versions of the input strings.  They're used to compute an offset, which is applied to one of the input strings, and the two locally allocated strings are no longer needed.
