### PR TITLE
Minor memory leak on error parsing config files

### DIFF
--- a/cgminer.c
+++ b/cgminer.c
@@ -2451,6 +2451,7 @@ static char *parse_config(json_t *config, bool fileconf)
 				} else {
 					snprintf(err_buf, sizeof(err_buf), "Parsing JSON option %s: %s",
 						p, err);
+                    free(name);
 					return err_buf;
 				}
 			}


### PR DESCRIPTION
This is a "memory leak" in the sense that, when an error is produced while parsing config files, memory that should be freed isn't; however the memory leaked contains config files names and the leak stops after the config files are processed, so they are bounded.   It probably wouldn't be worth fixing at all if the program terminated as a result, but it doesn't.  The errors are logged, but otherwise ignored, and the program continues to run. 

This pull request addresses only the leak.  The issue of whether `cgminer` *should* continue to start up with a bad config file is a separate issue not addressed in this pull request.  I would prefer that it didn't, but others might feel differently.