### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ to build this specific code on linux:
 	sudo cp 01-cgminer.rules /etc/udev/rules.d/
 	CFLAGS="-O2 -march=native" ./autogen.sh
 	./configure --enable-gekko
-	make
+	sudo make
 	sudo make install
+	sudo reboot
 	
 ### Option Summary ###
 


### PR DESCRIPTION
Without the reboot cgminer could not detect the Gekko NewPac. I looked everywhere for the solution and found that a simple reboot allowed the drivers to be initiated.